### PR TITLE
Adds "<queries>" section to AndroidManifest.xml

### DIFF
--- a/plugin/src/main/AndroidManifest.xml
+++ b/plugin/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
 
     <uses-permission android:name="android.permission.CAMERA"/>
 
+    <queries>
+        <package android:name="com.google.ar.core" />
+    </queries>
+
     <uses-feature
         android:name="android.hardware.camera.ar"
         android:required="true" />


### PR DESCRIPTION
Since Android Level 30 an app seems to need this section to specify which apps it wants to interact with. Since ARCore is distributed as an app aswell, this section seems to be needed for the plugin to work on smartphones with API Level 30+. My smartphone then shows the camera being accessed for a second in the top right with the green status indicator (https://source.android.com/docs/core/permissions/privacy-indicators)

See https://developer.android.com/guide/topics/manifest/queries-element for details on the queries element.

Note: This is the same pull request as https://github.com/GodotVR/godot_arcore/pull/10 with unnecessary commits removed, as I couldn't get the rebase to work